### PR TITLE
Add bounded soft-reference file hash cache

### DIFF
--- a/src/com/facebook/buck/util/cache/FileHashCache.java
+++ b/src/com/facebook/buck/util/cache/FileHashCache.java
@@ -34,6 +34,16 @@ public interface FileHashCache extends FileHashLoader {
 
   void invalidate(Path path);
 
+  /**
+   * Invalidate multiple paths in a single operation. The default implementation iterates and
+   * delegates to {@link #invalidate(Path)} for each entry.
+   */
+  default void invalidateAll(Iterable<? extends Path> paths) {
+    for (Path path : paths) {
+      invalidate(path);
+    }
+  }
+
   void invalidateAll();
 
   void set(Path path, HashCode hashCode) throws IOException;

--- a/src/com/facebook/buck/util/cache/impl/ComboFileHashCache.java
+++ b/src/com/facebook/buck/util/cache/impl/ComboFileHashCache.java
@@ -39,7 +39,7 @@ class ComboFileHashCache implements FileHashCacheEngine {
       ValueLoader<Long> sizeLoader,
       ProjectFilesystem filesystem) {
     this(
-        LoadingCacheFileHashCache.createWithStats(hashLoader, sizeLoader),
+        LoadingCacheFileHashCache.createWithStats(hashLoader, sizeLoader, 0, false),
         FileSystemMapFileHashCache.createWithStats(hashLoader, sizeLoader, filesystem));
   }
 


### PR DESCRIPTION
## Summary
- allow bulk invalidation for FileHashCache
- add bounded/soft reference file hash cache factories
- support LRU and soft value caching with periodic cleanup
- watch for multiple path events without locking and verify via tests

## Testing
- `./bin/buck test //test/com/facebook/buck/util/cache/impl:impl --test-selectors WatchedFileHashCacheTest -j 4` *(fails: No such file or directory: '/workspace/buck/ant-out/buck-info.json')*

------
https://chatgpt.com/codex/tasks/task_e_68b20b698f688326a0fb31fff28e8ebf