### PR TITLE
Add bounded and memory sensitive file hash caches

### DIFF
--- a/test/com/facebook/buck/util/cache/impl/DefaultFileHashCacheTest.java
+++ b/test/com/facebook/buck/util/cache/impl/DefaultFileHashCacheTest.java
@@ -160,6 +160,26 @@ public class DefaultFileHashCacheTest {
   }
 
   @Test
+  public void boundedCacheEvictsLeastRecentlyUsed() throws IOException {
+    Assume.assumeTrue(fileHashCacheMode == FileHashCacheMode.LOADING_CACHE);
+    ProjectFilesystem filesystem = new FakeProjectFilesystem();
+    DefaultFileHashCache cache =
+        DefaultFileHashCache.createBoundedFileHashCache(filesystem, 2);
+    Path p1 = Paths.get("p1");
+    filesystem.writeContentsToPath("1", p1);
+    cache.get(p1);
+    Path p2 = Paths.get("p2");
+    filesystem.writeContentsToPath("2", p2);
+    cache.get(p2);
+    Path p3 = Paths.get("p3");
+    filesystem.writeContentsToPath("3", p3);
+    cache.get(p3);
+    assertFalse(cache.getIfPresent(p1).isPresent());
+    assertTrue(cache.getIfPresent(p2).isPresent());
+    assertTrue(cache.getIfPresent(p3).isPresent());
+  }
+
+  @Test
   public void whenDirectoryIsPutThenInvalidatedCacheDoesNotContainPathOrChildren()
       throws IOException {
     ProjectFilesystem filesystem = new FakeProjectFilesystem();


### PR DESCRIPTION
## Summary
- allow LoadingCacheFileHashCache to accept custom CacheBuilder and add bounded/memory-sensitive variants
- provide factory methods on DefaultFileHashCache for bounded and memory sensitive caches
- support bulk invalidation and add LRU eviction test

## Testing
- `./bin/buck test //test/com/facebook/buck/util/cache/impl:DefaultFileHashCacheTest` *(fails: No such file or directory: '/workspace/buck/ant-out/buck-info.json')*


------
https://chatgpt.com/codex/tasks/task_e_68b3fb29b0608326bffa988053f10926